### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ medularis-django-utils (Medularis' Django utilities)
    :target: http://travis-ci.org/medularis/medularis-django-utils
 .. image:: https://coveralls.io/repos/medularis/medularis-django-utils/badge.png?branch=master
    :target: https://coveralls.io/r/medularis/medularis-django-utils
-.. image:: https://pypip.in/version/medularis-django-utils/badge.png
+.. image:: https://img.shields.io/pypi/v/medularis-django-utils.svg
    :target: https://pypi.python.org/pypi/medularis-django-utils/
    :alt: Latest version
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20medularis-django-utils))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `medularis-django-utils`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.